### PR TITLE
[FIX]: build command  to deploy with warnings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = 'CI = npm run build'
+command = 'CI='' npm run build'
 functions = "functions/"
 
 publish ='build'


### PR DESCRIPTION
Replacing CI = with CI='' and it should deploy on netlify with linting warnings. You were very close. I had the same problem once a long time ago and also took we a bit of reading and trying to get it right then.